### PR TITLE
Bump version and add device listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "limedriver"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python bindings for limedriver"
 authors = [{name = "Kumi", email = "limedriver@kumi.email"}]
 license = {file = "LICENSE"}

--- a/src/limedriver/limedriver.pyx
+++ b/src/limedriver/limedriver.pyx
@@ -7,6 +7,7 @@ from libc.string cimport memcpy, strcpy
 
 from libcpp.vector cimport vector
 from libcpp.string cimport string
+from libcpp.pair cimport pair
 
 import pathlib
 
@@ -94,6 +95,8 @@ cdef extern from "limedriver.h":
     cdef LimeConfig_t initializeLimeConfig(int Npulses)
 
     cdef int run_experiment_from_LimeCfg(LimeConfig_t config)
+
+    cdef pair[int, int] getChannelsFromInfo(string device)
 
     cdef vector[string] getDeviceList()
         
@@ -719,3 +722,7 @@ cdef class PyLimeConfig:
 def get_device_list():
     cdef vector[string] devices = getDeviceList()
     return [device.decode('utf-8') for device in devices] 
+
+def get_channels_for_device(device):
+    cdef pair[int, int] channels = getChannelsFromInfo(device)
+    return channels.first, channels.second

--- a/src/limedriver/limedriver.pyx
+++ b/src/limedriver/limedriver.pyx
@@ -724,5 +724,5 @@ def get_device_list():
     return [device.decode('utf-8') for device in devices] 
 
 def get_channels_for_device(device = ""):
-    cdef pair[int, int] channels = getChannelsFromInfo(device)
+    cdef pair[int, int] channels = getChannelsFromInfo(device.encode())
     return channels.first, channels.second

--- a/src/limedriver/limedriver.pyx
+++ b/src/limedriver/limedriver.pyx
@@ -723,6 +723,6 @@ def get_device_list():
     cdef vector[string] devices = getDeviceList()
     return [device.decode('utf-8') for device in devices] 
 
-def get_channels_for_device(device):
+def get_channels_for_device(device = ""):
     cdef pair[int, int] channels = getChannelsFromInfo(device)
     return channels.first, channels.second

--- a/src/limedriver/limedriver.pyx
+++ b/src/limedriver/limedriver.pyx
@@ -5,13 +5,15 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.stdlib cimport malloc, free
 from libc.string cimport memcpy, strcpy
 
-
+from libcpp.vector cimport vector
 from libcpp.string cimport string
 
 import pathlib
 
 cdef extern from "limedriver.h":
     cdef struct LimeConfig_t:
+        string device
+
         float srate
         int channel
         int TX_matching
@@ -92,6 +94,8 @@ cdef extern from "limedriver.h":
     cdef LimeConfig_t initializeLimeConfig(int Npulses)
 
     cdef int run_experiment_from_LimeCfg(LimeConfig_t config)
+
+    cdef vector[string] getDeviceList()
         
 
 cdef class PyLimeConfig:
@@ -704,3 +708,6 @@ cdef class PyLimeConfig:
         path = pathlib.Path(path).absolute()
         return path
  
+def get_device_list():
+    cdef vector[string] devices = getDeviceList()
+    return [device.decode('utf-8') for device in devices] 

--- a/src/limedriver/limedriver.pyx
+++ b/src/limedriver/limedriver.pyx
@@ -661,6 +661,14 @@ cdef class PyLimeConfig:
  
     # String properties
     @property
+    def device(self):
+        return self._config.device.decode('utf-8')
+    
+    @device.setter
+    def device(self, str value):
+        self._config.device = value.encode('utf-8')
+
+    @property
     def file_pattern(self):
         return self._config.file_pattern.decode()
 


### PR DESCRIPTION
Updated the project version reflecting new features. Extended the LimeConfig_t struct to include a device string supporting device specification. Introduced a new function `get_device_list` in the Python binding, allowing users to retrieve a list of available devices, enhancing usability. This change improves user interactions with the hardware, making device management more intuitive.

N.B.: This depends on the merge of https://github.com/nqrduck/LimeDriver/pull/20 and a bump of the LimeDriver submodule.